### PR TITLE
Fix debug code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
               }
               node(id: $projectId) {
                 ... on ProjectNext {
-                  items(first: 2, after: $cursor) {
+                  items(first: 100, after: $cursor) {
                     pageInfo {
                       hasNextPage
                       endCursor


### PR DESCRIPTION
- 1回辺りの検索件数が2件のままだったので RateLimit 的に効率が悪いため、一旦固定値の100にしておく