### PR TITLE
:gear: Use `actions-get-project-id@v2`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Get Project Id
-      uses: monry/actions-get-project-id@develop
+      uses: monry/actions-get-project-id@v2
       id: get-project-id
       with:
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
- `v2` としてリリースしたので、そちらへの利用に切り替える